### PR TITLE
The goal here is to utilize the sprockets tmp/cache/assets cache.

### DIFF
--- a/lib/parcels/environment.rb
+++ b/lib/parcels/environment.rb
@@ -30,6 +30,7 @@ module Parcels
       end
 
       widget_tree.add_workaround_directory_to_sprockets!(sprockets_environment)
+      widget_tree.ensure_workaround_directory_is_set_up_during_init!
     end
 
     def widget_class_from_file(full_path)

--- a/lib/parcels/rails/railtie.rb
+++ b/lib/parcels/rails/railtie.rb
@@ -3,7 +3,7 @@ require "parcels"
 module Parcels
   module Rails
     class Railtie < ::Rails::Railtie
-      initializer :parcels, :after => [ :append_assets_path, :finisher_hook ] do |app|
+      initializer :parcels, :after => :load_config_initializers do |app|
         parcels = ::Rails.application.assets.parcels
 
         ::ActionController::Base.view_paths.map(&:to_s).each do |view_path|

--- a/lib/parcels/sprockets.rb
+++ b/lib/parcels/sprockets.rb
@@ -15,6 +15,25 @@ module Parcels
   end
 end
 
+::Sprockets::Base.class_eval do
+
+  alias_method :orig_each_logical_path, :each_logical_path
+
+  def each_logical_path(*args, &block)
+    if block_given?
+      orig_each_logical_path(*args) do |logical_path|
+        unless ::Parcels.is_fortitude_logical_path?(logical_path)
+          block.call(logical_path)
+        end
+      end
+    else
+      orig_each_logical_path(*args).reject do |logical_path|
+        ::Parcels.is_fortitude_logical_path?(logical_path)
+      end
+    end
+  end
+end
+
 ::Sprockets::Environment.class_eval do
   def parcels
     @parcels ||= ::Parcels::Environment.new(self)

--- a/lib/parcels/sprockets.rb
+++ b/lib/parcels/sprockets.rb
@@ -16,22 +16,21 @@ module Parcels
 end
 
 ::Sprockets::Base.class_eval do
-
-  alias_method :orig_each_logical_path, :each_logical_path
-
-  def each_logical_path(*args, &block)
+  def each_logical_path_with_parcels(*args, &block)
     if block_given?
-      orig_each_logical_path(*args) do |logical_path|
+      each_logical_path_without_parcels(*args) do |logical_path|
         unless ::Parcels.is_fortitude_logical_path?(logical_path)
           block.call(logical_path)
         end
       end
     else
-      orig_each_logical_path(*args).reject do |logical_path|
+      each_logical_path_without_parcels(*args).reject do |logical_path|
         ::Parcels.is_fortitude_logical_path?(logical_path)
       end
     end
   end
+
+  alias_method_chain :each_logical_path, :parcels
 end
 
 ::Sprockets::Environment.class_eval do

--- a/lib/parcels/widget_tree.rb
+++ b/lib/parcels/widget_tree.rb
@@ -89,6 +89,25 @@ module Parcels
       end
     end
 
+    # not ideal since this same traversal happens in add_all_widgets_to_sprockets_context
+    # fortunately we have an early return if we run into a usable parcel
+    def ensure_workaround_directory_is_set_up_during_init!
+      Find.find(root) do |path|
+        full_path = File.expand_path(path, root)
+        stat = File.stat(full_path)
+        next unless stat.file?
+
+        extension = File.extname(full_path).strip.downcase
+        if (klass = EXTENSION_TO_PARCEL_CLASS_MAP[extension])
+          parcel = klass.new(self, full_path)
+          if parcel.usable? # note the lack of set_names here
+            ensure_workaround_directory_is_set_up!
+            return
+          end
+        end
+      end
+    end
+
     private
     EXTENSION_TO_PARCEL_CLASS_MAP   = {
       '.rb'.freeze => ::Parcels::FortitudeInlineParcel,

--- a/parcels.gemspec
+++ b/parcels.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "tilt", ">= 1.2"
 
   if RUBY_VERSION =~ /^1\.8\./
     spec.add_development_dependency "nokogiri", "< 1.6.0"


### PR DESCRIPTION
Rails3 never used this cache since turbosprockets always deleted
it when doing a precompile.

So, we create the .parcels_sprockets_workaround directory early
enough so that hike's immutable cache is initially created
with a currect 'stat' entry for files inside this directory.
If this doesn't happen, hike's immutable cache writes an entry
with a 'nil' stat for fortitude files that blows up the second
time you attempt to precompile assets.

Also, we need to ensure that fortitude files are ignored during
initial compilation step. The static compiler doesn't exist
in Rails4 anymore, specifically the method each_logical_path was
moved to base.rb. This behavior was previously handled
inside sprockets.rb monkey patch of ::Sprockets::StaticCompiler
and is now handled by the monkey patch to ::Sprockets::Base.
