### PR TITLE
Fix multi-process concurrent execution

### DIFF
--- a/lib/parcels/widget_tree.rb
+++ b/lib/parcels/widget_tree.rb
@@ -180,7 +180,11 @@ and try again.}
 
     def create_symlink!(prefix)
       Dir.chdir(workaround_directory) do
-        FileUtils.ln_s(symlink_target, prefix)
+        begin
+          FileUtils.ln_s(SYMLINK_TARGET, prefix)
+        rescue Errno::EEXIST
+          # file exists, we're good
+        end
       end
     end
 

--- a/lib/parcels/widget_tree.rb
+++ b/lib/parcels/widget_tree.rb
@@ -181,7 +181,7 @@ and try again.}
     def create_symlink!(prefix)
       Dir.chdir(workaround_directory) do
         begin
-          FileUtils.ln_s(SYMLINK_TARGET, prefix)
+          FileUtils.ln_s(symlink_target, prefix)
         rescue Errno::EEXIST
           # file exists, we're good
         end


### PR DESCRIPTION
In an environment where multiple processes are
running this code concurrently, it may be the case
that one process creates the symlink before the
others, thus causing an Errno::EEEXIST error.

Just rescue the error since that's the end state
we want to be in
