### PR TITLE
Fix race condition checking workaround directory

### DIFF
--- a/lib/parcels/widget_tree.rb
+++ b/lib/parcels/widget_tree.rb
@@ -134,15 +134,11 @@ module Parcels
     end
 
     def ensure_workaround_directory_exists!
-      unless File.directory?(workaround_directory)
-        if File.exist?(workaround_directory)
-          raise Errno::EEXIST, %{Parcels uses the directory '#{workaround_directory}' internally
+      FileUtils.mkdir_p(workaround_directory)
+    rescue Errno::EEXIST
+      raise Errno::EEXIST, %{Parcels uses the directory '#{workaround_directory}' internally
   (to allow us to safely add assets to Sprockets without treading on the global asset namespace);
   however, there is already something at that path that is not a directory.}
-        end
-
-        FileUtils.mkdir_p(workaround_directory)
-      end
     end
 
     def ensure_nothing_else_is_in_workaround_directory!


### PR DESCRIPTION
With the old code, it was possible for the workaround directory to not
exist when checking if it is a directory, then have been created by
another process by the time it is checked for in order to raise the
error message.

Since FileUtils.mkdir_p will raise an error if attempting to create a 
directory with the same name as a file but will succeed if a directory
with the same name exists, the code can be simplified to eliminate the
race condition.
